### PR TITLE
Don't assign ISRCs to empty track numbers (cdrdao).

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -271,6 +271,9 @@ def backendError(backend, e):
             % (backend, e.errno, e.strerror))
     sys.exit(1)
 
+def sanitizeIsrc(isrc):
+    return isrc.strip('" ').replace("-", "")
+
 def gatherIsrcs(backend, device):
     backend_output = []
     devnull = open(os.devnull, "w")
@@ -294,7 +297,8 @@ def gatherIsrcs(backend, device):
                         print "can't find ISRC in:", text
                         continue
                     trackNumber = int(m.group(1))
-                    isrc = m.group(2) + m.group(3) + m.group(4) + m.group(5)
+                    isrc = sanitizeIsrc(m.group(2) + m.group(3) +
+                                        m.group(4) + m.group(5))
                     backend_output.append((trackNumber, isrc))
 
     elif backend == "cdrdao":
@@ -317,7 +321,7 @@ def gatherIsrcs(backend, device):
                         if words[0] == "//":
                             trackNumber = int(words[2])
                         elif words[0] == "ISRC" and trackNumber is not None:
-                            isrc = words[1].strip('" ')
+                            isrc = sanitizeIsrc(words[1])
                             backend_output.append((trackNumber, isrc))
                             # safeguard against missing trackNumber lines
                             trackNumber = None
@@ -343,7 +347,8 @@ def gatherIsrcs(backend, device):
                     print "can't find ISRC in:", line
                     continue
                 trackNumber = int(m.group(1))
-                isrc = m.group(2) + m.group(3) + m.group(4) + m.group(5)
+                isrc = sanitizeIsrc(m.group(2) + m.group(3) + m.group(4) +
+                                    m.group(5))
                 backend_output.append((trackNumber, isrc))
 
     return backend_output


### PR DESCRIPTION
If you have a release that stores ISRCs both on their own and in the CD-TEXT, the cdrdao parser would assign the ISRC both to the trackNumber ("[1, ISRC]"), but also to an empty track ("[None, ISRC]"). This would cause errors on line 658[1] as you cannot add type None to type Int.

[1] "track = tracks[trackNumber + trackOffset - 1]"
