### PR TITLE
Declare discId as global.

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -325,6 +325,7 @@ def getDisc(device, submit=False):
         printError("DiscID calculation failed:", str(e))
         sys.exit(1)
 
+    global discId
     discId = disc.getId()
     discTrackCount = len(disc.getTracks())
 


### PR DESCRIPTION
In commit 98d9f9839a the assignment of the discId variable was moved to the (new) function getDisc(). As variables assigned inside functions are local to the function unless otherwise specified, the discID was no longer available further down the script, which would cause an error when looking up discs on multi-disc releases.
