### PR TITLE
Use xdg-open or the webbrowser module rather than firefox as default

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -21,7 +21,7 @@ The project is hosted on
 https://github.com/JonnyJD/musicbrainz-isrcsubmit
 """
 
-__version__ = "2.0.0-beta.2"
+__version__ = "2.0.0-dev"
 AGENT_NAME = "isrcsubmit.py"
 MUSICBRAINZ_SERVER = "musicbrainz.org"
 # starting with highest priority
@@ -829,7 +829,11 @@ def cleanup_isrcs(release, isrcs):
 
             url = "http://%s/isrc/%s" % (MUSICBRAINZ_SERVER, isrc)
             if user_input("Open ISRC in the browser? [Y/n] ") != "n":
-                Popen([options.browser, url])
+                if options.debug:
+                    Popen([options.browser, url])
+                else:
+                    devnull = open(os.devnull, "w")
+                    Popen([options.browser, url], stdout=devnull)
                 user_input("(press <return> when done with this ISRC) ")
 
 


### PR DESCRIPTION
jozo gave a hint that there are standard tools available to open a webbrrowser:

xdg-open:
- http://portland.freedesktop.org/xdg-utils-1.0/xdg-open.html
- https://wiki.archlinux.org/index.php/Xdg-open

The [webbrowser module](http://docs.python.org/2/library/webbrowser.html)
