### PR TITLE
parameter to set the mb server

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -546,7 +546,9 @@ class Disc(object):
     @property
     def submission_url(self):
         url = self._disc.submission_url
-        return url.replace("mm.musicbrainz.org", options.server)
+        # mm.mb.o points to mb.o, if present in the url
+        url = url.replace("//mm.", "//")
+        return url.replace("musicbrainz.org", options.server)
 
     @property
     def release(self):


### PR DESCRIPTION
Sometimes one can submit isrcs only to beta. Example: http://tickets.musicbrainz.org/browse/MBS-6213

So there is a use case other than testing isrcsubmit.

`--server` would be a good name.
