### PR TITLE
make it usable as python module, stable api?

### DIFF
--- a/import_example.py
+++ b/import_example.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+
+import isrcsubmit
+
+if __name__ == "__main__":
+    options = isrcsubmit.gather_options([])
+
+    print("isrcsubmit %s" % isrcsubmit.__version__)
+    print("backends: %s" % ", ".join(isrcsubmit.BACKENDS))
+    device = "/dev/cdrom"
+    #backend = isrcsubmit.find_backend()
+    #print(isrcsubmit.get_prog_version(options.backend))
+    disc = isrcsubmit.get_disc(device, options.backend)
+    print(isrcsubmit.gather_isrcs(disc, options.backend, device))


### PR DESCRIPTION
Part of the restructuring for version 2 was also to make it possibly to import isrcsubmit (technically).

I should make sure (= do some testing) that this is possible.

Another thing to consider is then to split the functions/classes in "internal" and "exported". That is the internal stuff can change, but things other people really might want to use, should keep the same API (until major version changes occur).

Things that are already known to be useful for others:
- `Disc.getRelease()` (not sure if in this form)
- `gather_isrcs()` (needs `Disc` as input currently)
