### PR TITLE
list more release info (incl. mbid), always ask for submission

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -411,7 +411,7 @@ def print_release(release, position=None):
     else:
         print("")
     if position is None:
-        print_encoded("Release Event:\t%s\t%s\n" % (country, date))
+        print_encoded("Release Event:\t%s\t%s\n" % (date, country))
         print_encoded("Barcode:\t%s\n" % release.get("barcode") or "")
         print_encoded("Catalog No.:\t%s\n" % catnumbers)
         print_encoded("MusicBrainz ID:\t%s\n" % release["id"])


### PR DESCRIPTION
It is a bit weird to display the somewhat "internal" MBID in the output of isrcsubmit.
However, people might want to check if the release they have chosen is "really" what they meant (not trusting barcode, cat # etc.)
