### PR TITLE
isrcsubmit.py --version displays the version twice

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -77,6 +77,7 @@ def script_version():
     return "isrcsubmit %s by JonnyJD for MusicBrainz" % __version__
 
 def print_help(option=None, opt=None, value=None, parser=None):
+    print("%s" % script_version())
     print(\
 """
 This python script extracts ISRCs from audio cds and submits them to MusicBrainz (musicbrainz.org).
@@ -92,6 +93,10 @@ The ISRC-track relationship we found on our disc is taken as our correct evaluat
 Please report bugs on https://github.com/JonnyJD/musicbrainz-isrcsubmit""")
     sys.exit(0)
 
+def print_usage(option=None, opt=None, value=None, parser=None):
+    print("%s\n" % script_version())
+    parser.print_help()
+    sys.exit(0)
 
 class Isrc(object):
     def __init__(self, isrc, track=None):
@@ -165,7 +170,7 @@ def gather_options(argv):
     parser.set_usage(
             "{prog} [options] [user] [device]\n       {prog} -h".format(
             prog=SCRIPTNAME))
-    parser.add_option("-h", action="help",
+    parser.add_option("-h", action="callback", callback=print_usage,
             help="Short usage help")
     parser.add_option("--help", action="callback", callback=print_help,
             help="Complete help for the script")


### PR DESCRIPTION
```
$ ./isrcsubmit.py --version
isrcsubmit 2.0.0-dev by JonnyJD for MusicBrainz
using discid version 1.1.0
isrcsubmit 2.0.0-dev by JonnyJD for MusicBrainz
```

The reason is that the first version information is printed before the options are parsed, so the version is alway at the top.

Switching them would lead to having usage information without the version and possibly displaying the backend version before our own version.

short: This has to do with `OptionParser`.
