### PR TITLE
Use keyring to store/retrieve password if it is available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Dependencies:
 * Python 2 >= 2.6 or Python 3 >= 3.1
 * python-discid_ >= 1.0.0 (or python-libdiscid_ >= 0.2.0)
 * python-musicbrainzngs_ >= 0.4
-* keyring_ >= 2.0 (optional)
+* keyring_ (optional)
 
 .. _python-discid: http://python-discid.readthedocs.org/
 .. _python-libdiscid: http://pythonhosted.org/python-libdiscid


### PR DESCRIPTION
keyring allows to access keyrings like gnome-keyring, kwallet, some OS X key chain, etc. and, if they should not be available, provides an encrypted keyring itself. The pull request implements the following:

If keyring is available, check if a password is stored and use it. Should the stored password be wrong, the password is deleted from the keyring and user is asked to enter the password. If no password is stored in the keyring, the user is asked to enter it and then it will be stored in the keyring for the next time.
