### PR TITLE
The '/org/freedesktop/secrets/aliases/default' object does not exist

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -58,8 +58,13 @@ import musicbrainzngs
 from musicbrainzngs import AuthenticationError, ResponseError, WebServiceError
 
 try:
-    import keyring
+    from secretstorage import ItemNotFoundException
 except ImportError:
+    ItemNotFoundException = LookupError
+try:
+    import keyring
+except (ImportError, ItemNotFoundException):
+    # importing keyring can fail if no actual keyring is configured (#90)
     keyring = None
 
 try:


### PR DESCRIPTION
When having python-keyring and python-secretstorage installed, the following exception can happen when importing `keyring`:

```
ERROR:dbus.proxies:Introspect error on :1.158:/org/freedesktop/secrets/aliases/default: dbus.exceptions.DBusException: org.freedesktop.Secret.Error.NoSuchObject: The '/org/freedesktop/secrets/aliases/default' object does not exist
Traceback (most recent call last):
  File "/usr/lib/python3.3/site-packages/secretstorage/util.py", line 23, in function_out
    return function_in(*args, **kwargs)
  File "/usr/lib/python3.3/site-packages/dbus/proxies.py", line 70, in __call__
    return self._proxy_method(*args, **keywords)
  File "/usr/lib/python3.3/site-packages/dbus/proxies.py", line 145, in __call__
    **keywords)
  File "/usr/lib/python3.3/site-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.Secret.Error.NoSuchObject: The '/org/freedesktop/secrets/aliases/default' object does not exist

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./isrcsubmit.py", line 61, in <module>
    import keyring
  File "/usr/lib/python3.3/site-packages/keyring/__init__.py", line 12, in <module>
    from .core import (set_keyring, get_keyring, set_password, get_password,
  File "/usr/lib/python3.3/site-packages/keyring/core.py", line 180, in <module>
    init_backend()
  File "/usr/lib/python3.3/site-packages/keyring/core.py", line 59, in init_backend
    set_keyring(load_config() or _get_best_keyring())
  File "/usr/lib/python3.3/site-packages/keyring/core.py", line 67, in _get_best_keyring
    keyrings = backend.get_all_keyring()
  File "/usr/lib/python3.3/site-packages/keyring/util/__init__.py", line 24, in wrapper
    func.always_returns = func(*args, **kwargs)
  File "/usr/lib/python3.3/site-packages/keyring/backend.py", line 127, in get_all_keyring
    exceptions=TypeError))
  File "/usr/lib/python3.3/site-packages/keyring/util/__init__.py", line 35, in suppress_exceptions
    for callable in callables:
  File "/usr/lib/python3.3/site-packages/keyring/backend.py", line 119, in is_class_viable
    keyring_cls.priority
  File "/usr/lib/python3.3/site-packages/keyring/util/properties.py", line 22, in __get__
    return self.fget.__get__(None, owner)()
  File "/usr/lib/python3.3/site-packages/keyring/backends/SecretService.py", line 27, in priority
    secretstorage.Collection(bus)
  File "/usr/lib/python3.3/site-packages/secretstorage/collection.py", line 43, in __init__
    self.collection_props_iface.Get(COLLECTION_IFACE, 'Label')
  File "/usr/lib/python3.3/site-packages/secretstorage/util.py", line 28, in function_out
    raise ItemNotFoundException(e.get_dbus_message())
secretstorage.exceptions.ItemNotFoundException: The '/org/freedesktop/secrets/aliases/default' object does not exist
```

This is reported upstream at https://bitbucket.org/kang/python-keyring-lib/issue/133/on-import

My current guess is, that this happens when no keyring is configured (or no SecretService daemon is running?).
