### PR TITLE
NameError: name 'FileNotFoundError' is not defined when a specific browser is chosen

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -410,7 +410,7 @@ def open_browser(url, exit=False, submit=False):
                 else:
                     with open(os.devnull, "w") as devnull:
                         Popen([options.browser, url], stdout=devnull)
-            except FileNotFoundError as err:
+            except OSError as err:
                 error = ["Couldn't open the url in %s: %s"
                             % (options.browser, str(err))]
                 if submit:


### PR DESCRIPTION
In Python <= 3.2 Popen throws `OSError`. Starting with Python 3.3 it throws `FileNotFoundError` which is a subclass.

isrcsubmit expects FileNotFoundError, leading to an uncatched `NameError` instead on Python <= 3.2.

The impact is quite small, because the problem only shows up when a browser is explicitely set as parameter or in the config _and_ it is not found.
And in that case it fails either way, but failing with an error message is better than with this NameError.

The problem was originally found by Jozo with PyFlakes.
