### PR TITLE
fix display of "missing backend" error

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -369,7 +369,7 @@ def find_backend():
     if backend is None:
         print_error("Cannot find a backend to extract the ISRCS!",
                     "Isrcsubmit can work with one of the following:",
-                    "  " + ", ".join(backend))
+                    "  " + ", ".join(BACKENDS))
         sys.exit(-1)
 
     return backend


### PR DESCRIPTION
Fix listing the possible backends when no working backend can be found.
The regression was introduced in
7109839c9e2617e4bef92a19f5b862e5237d6cef (pre 2.0).

This fixes #95.