### PR TITLE
Fix discid.read mocking

### DIFF
--- a/test_isrcsubmit.py
+++ b/test_isrcsubmit.py
@@ -153,7 +153,7 @@ def _read(device=None, features=[]):
         with open(file_name, "rb") as disc_file:
             return pickle.load(disc_file)
 
-discid.read = _read
+isrcsubmit.discid.read = _read
 
 
 # mock cdrdao reading


### PR DESCRIPTION
Need to override discid.read in isrcsubmit.py, not test_isrcsubmit.py for the mockery to work properly.