### PR TITLE
Remove `--fast-toc` from cdrdao's options

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -893,10 +893,9 @@ def gather_isrcs(disc, backend, device):
         if os.name == "nt":
             if device != discid.get_default_device():
                 logger.warning("cdrdao uses the default device")
-            args = [backend, "read-toc", "--fast-toc", "-v", "0", tmpfile]
+            args = [backend, "read-toc", "-v", "0", tmpfile]
         else:
-            args = [backend, "read-toc", "--fast-toc", "--device", device,
-                "-v", "0", tmpfile]
+            args = [backend, "read-toc", "--device", device, "-v", "0", tmpfile]
         try:
             if options.debug:
                 proc = Popen(args, stdout=devnull)


### PR DESCRIPTION
In my personal usage `--fast-toc` almost always results in isrcsubmit.py finding duplicate ISRCs. Removing `--fast-toc` makes the reading significantly slower, but it also means that it doesn't get duplicate ISRCs meaning it only needs to run once.