### PR TITLE
Fix for python 3.8

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -43,6 +43,8 @@ from datetime import datetime
 from optparse import OptionParser
 from subprocess import Popen, PIPE, call
 
+os.add_dll_directory(os.getcwd())
+
 try:
     import discid
     from discid import DiscError


### PR DESCRIPTION
See here: https://stackoverflow.com/questions/59014318/filenotfounderror-could-not-find-module-libvlc-dll