### PR TITLE
fix: error on macOS with Python 3

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -439,7 +439,7 @@ def get_real_mac_device(option_device):
     """
     proc = Popen(["drutil", "status", "-drive", option_device], stdout=PIPE)
     try:
-        given = proc.communicate()[0].splitlines()[3].split("Name:")[1].strip()
+        given = decode(proc.communicate()[0]).splitlines()[3].split("Name:")[1].strip()
     except IndexError:
         print_error("could not find real device",
                      "maybe there is no disc in the drive?")


### PR DESCRIPTION
without this patch, script will stop with error:

```
    given = proc.communicate()[0].splitlines()[3].split("Name:")[1].strip()
TypeError: a bytes-like object is required, not 'str'
```