### PR TITLE
Explicitly declare the package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(name="isrcsubmit",
         url="https://github.com/JonnyJD/musicbrainz-isrcsubmit",
         requires=["discid(>=1.0.0)", "musicbrainzngs(>=0.4)"],
         python_requires='>=3.7',
+        packages=["isrcsubmit"],
         scripts=["isrcsubmit.py"],
         license="GPLv3+",
         classifiers=[


### PR DESCRIPTION
Setuptools recently added automatic discovery of packages and namespaces within given source trees/projects, however `isrcsubmit`’s current layout does not play well with this autodiscovery.

Explicitly declaring which Python package is being touched by using this setup.py is probably the easiest and quickest way to remedy this. We may want to switch to another solution down the line, but this should work okay for the time being.

See https://setuptools.pypa.io/en/latest/userguide/package_discovery.html for more details.

Fixes https://github.com/JonnyJD/musicbrainz-isrcsubmit/issues/140