### PR TITLE
Windows Python 3.8+: Search current folder for discid.dll

### DIFF
--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -43,7 +43,9 @@ from datetime import datetime
 from optparse import OptionParser
 from subprocess import Popen, PIPE, call
 
-os.add_dll_directory(os.getcwd())
+# Windows Python 3.8+ scan current folder for discid.dll
+if os.name == "nt" and sys.version_info >= (3,8):
+    os.add_dll_directory(os.getcwd())
 
 try:
     import discid

--- a/isrcsubmit.py
+++ b/isrcsubmit.py
@@ -43,6 +43,8 @@ from datetime import datetime
 from optparse import OptionParser
 from subprocess import Popen, PIPE, call
 
+os.add_dll_directory(os.getcwd())
+
 try:
     import discid
     from discid import DiscError


### PR DESCRIPTION
Fixes https://github.com/JonnyJD/musicbrainz-isrcsubmit/issues/143 (Windows Python 3.8+ **_Could not find module 'discid.dll'_**), without tampering with other setups.

This https://github.com/JonnyJD/musicbrainz-isrcsubmit/pull/125 fix from @omgitsraven was NG for Python 3.7 and less, while OK for Python 3.8+.
I found how to test Python version with https://stackoverflow.com/a/3016198/2236179 and I also test if script is running in Windows.

Tested on Linux (condition not met, do the script runs good as usual) and Windows Python 3.10.1 (condition met, fixes #143 and now the script is running good).
The script works in both cases.

I no longer have old python version but I have tested my version condition and it should work to prevent the new line in python 3.7 and earlier.

Then something must be done to bump version number and to publish new version zip files.

## PATCH

If you want to test in your environment, the patch is to insert the following code, before the first `try` of the script:

```py
# Windows Python 3.8+ scan current folder for discid.dll
if os.name == "nt" and sys.version_info >= (3,8):
    os.add_dll_directory(os.getcwd())
```


## TEST

| OS                 | Python | 2.1.1-beta | Patched 2.1.1-beta | 3.0.0-dev | Patched 3.0.0-dev |
|--------------------|--------|------------|--------------------|-----------|-------------------|
| Debian 11  64 bits | 3.9.2  | :+1:       | :+1:               | :+1:      | :+1:              |
| Windows XP 32 bits | 3.4.3  | :+1:       | :+1:               | :+1:      | :+1:              |
| Windows 11 64 bits | 3.10.7 | :x:        | :+1:               | :x:       | :+1:              |

