### PR TITLE
Run in same terminal

### DIFF
--- a/isrcsubmit.bat
+++ b/isrcsubmit.bat
@@ -2,6 +2,8 @@
 setlocal
 echo.
 for /f "tokens=2 delims=:." %%x in ('chcp') do set cp=%%x
-chcp 65001 >NUL
+chcp 65001 >nul
 python "%~dp0isrcsubmit.py" %*
-chcp %cp% >NUL
+chcp %cp% >nul
+echo %cmdcmdline%|findstr /c:"%~nx0" >nul
+if %errorlevel% equ 0 echo.&pause

--- a/isrcsubmit.bat
+++ b/isrcsubmit.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 echo.
 for /f "tokens=2 delims=:." %%x in ('chcp') do set cp=%%x
 chcp 65001 >NUL

--- a/isrcsubmit.bat
+++ b/isrcsubmit.bat
@@ -1,5 +1,6 @@
 @echo off
-for /f "tokens=2 delims=:." %%x in ('chcp') do set cp=%%x
-chcp 65001>NUL & cmd /c "isrcsubmit.py %*" & chcp %cp%>NUL
 echo.
-pause
+for /f "tokens=2 delims=:." %%x in ('chcp') do set cp=%%x
+chcp 65001 >NUL
+python "%~dp0isrcsubmit.py" %*
+chcp %cp% >NUL


### PR DESCRIPTION
Summary
=======

Patching the Windows-only `isrcsubmit.bat` file.

Without this patch
------------------

- The standard output is displayed in another temporary terminal window (no time to see it)
- The script always pauses at the end, even when ran from the command line (odd and annoying)

With this patch
---------------

- The standard output is displayed in current terminal window (like in Linux)
- If the script is run from command line, there is no annoying pause at the end (like in Linux)

---

I have a new PC with Windows 10 Pro and the `isrcsubmit.bat` command is unfortunately:

1. Launching `isrcsubmit.py` in new window
2. Closing this new window as soon as the script is ended
3. Pausing the parent window with nothing visible (as the script was run in new window, now closed)

Running `python <path>\isrcsubmit.py` instead of `isrcsubmit.py` fixes this problem.

I also fix the problem that work variable `cp` is added to environment variables.
I keep it local to the script, instead, with `setlocal`.

---

I have also added a code to pause the script only when launched from file explorer, with mouse, and not when launched from command line.