### PR TITLE
Drop .py extension from entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(name="isrcsubmit",
         py_modules=["isrcsubmit"],
         entry_points={
             'console_scripts': [
-                'isrcsubmit.py=isrcsubmit:main',
+                'isrcsubmit=isrcsubmit:main',
             ],
         },
         license="GPLv3+",


### PR DESCRIPTION
This change is part of Debian since 2013.